### PR TITLE
Add support to build rpms directly from make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,9 +18,11 @@ gsettings_SCHEMAS = org.meego.activesyncd.gschema.xml org.meego.activesyncd.acco
 @GSETTINGS_RULES@
 
 # full set of directories for "make dist"
-DIST_SUBDIRS = . libeasaccount/src libeasclient libeasaccount/tests eas-daemon check_tests libevoeas camel meego QtActivesyncdConfig po
+DIST_SUBDIRS = . libeasaccount/src libeasclient libeasaccount/tests eas-daemon check_tests libevoeas camel meego QtActivesyncdConfig po collection configuration
 # subset of that list for "make && make install"
 SUBDIRS = . libeasaccount/src libeasclient eas-daemon check_tests $(CAMEL_DIRS) $(MEEGO_DIR) $(QTCONFIG_DIR) po collection configuration
+
+dist_noinst_DATA = $(gsettings_SCHEMAS)
 
 EXTRA_DIST = autogen.sh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,3 +28,25 @@ EXTRA_DIST = autogen.sh
 
 pkgconfigdir = ${libdir}/pkgconfig
 pkgconfig_DATA = libeasaccount.pc libeasclient.pc
+
+# make [s]rpms
+RPMBUILD ?= $(PWD)/rpmbuild
+
+rpmroot:
+	$(MKDIR_P) $(RPMBUILD)/BUILD
+	$(MKDIR_P) $(RPMBUILD)/RPMS
+	$(MKDIR_P) $(RPMBUILD)/SOURCES
+	$(MKDIR_P) $(RPMBUILD)/SPECS
+	$(MKDIR_P) $(RPMBUILD)/SRPMS
+
+rpmbrprep: dist-xz rpmroot
+	cp $(builddir)/contrib/evolution-activesync.spec $(RPMBUILD)/SPECS
+	cp $(distdir).tar.xz $(RPMBUILD)/SOURCES
+
+rpms: rpmbrprep
+	cd $(RPMBUILD); \
+	rpmbuild --define "_topdir $(RPMBUILD)" -ba SPECS/evolution-activesync.spec
+
+srpm: rpmbrprep
+	cd $(RPMBUILD); \
+	rpmbuild --define "_topdir $(RPMBUILD)" -bs SPECS/evolution-activesync.spec

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT(evolution-activesync, 0.92)
 AC_PREREQ([2.59])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([1.10 no-define dist-xz no-dist-gzip])
+AM_INIT_AUTOMAKE([1.10 no-define dist-xz no-dist-gzip tar-pax])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Checks for libraries.

--- a/contrib/evolution-activesync.spec
+++ b/contrib/evolution-activesync.spec
@@ -1,0 +1,77 @@
+Name:		evolution-activesync
+Version:	0.92
+Release:	1%{?dist}
+Summary:	An Evolution plugin to access ActiveSync servers
+
+Group:		Applications/Productivity
+License:	LGPL2.1 and Apache
+URL:		https://github.com/GNOME/evolution-activesync
+Source0:	http://ftp.gnome.org/pub/GNOME/sources/%{name}/%{version}/%{name}-%{version}.tar.xz
+
+BuildRequires:	evolution-devel libwbxml-devel check-devel gcc-c++
+BuildRequires:  libgnome-keyring-devel dbus-glib-devel GConf2-devel
+Requires:	evolution libwbxml
+
+%description
+An Evolution plugin to access ActiveSync servers
+
+
+%package devel
+Summary:        Development files for evolution-activesync
+Group:          Development/Libraries
+License:	LGPL2.1 and Apache
+
+%description devel
+Development libraries for Evolution ActiveSync
+
+
+%prep
+%setup -q
+
+
+%build
+%configure
+make %{?_smp_mflags}
+
+
+%install
+make install DESTDIR=%{buildroot}
+rm -f %{buildroot}/%{_libdir}/evolution-data-server/camel-providers/libcameleas.la
+rm -f %{buildroot}/%{_libdir}/evolution-data-server/registry-modules/module-eas-backend.la
+rm -f %{buildroot}/%{_libdir}/evolution-data-server/libevoeas.la
+rm -f %{buildroot}/%{_libdir}/evolution/modules/module-eas-mail-config.la
+rm -f %{buildroot}/%{_libdir}/libeas*.la
+
+
+%files
+%doc
+%{_libdir}/evolution-data-server/camel-providers/libcameleas.so
+%{_libdir}/evolution-data-server/camel-providers/libcameleas.urls
+%{_libdir}/evolution-data-server/registry-modules/module-eas-backend.so
+%{_libdir}/evolution-data-server/libevoeas.so.0
+%{_libdir}/evolution-data-server/libevoeas.so.0.0.0
+%{_libdir}/evolution/modules/module-eas-mail-config.so
+%{_libdir}/libeas.so.0
+%{_libdir}/libeas.so.0.0.0
+%{_libdir}/libeasaccount.so.0
+%{_libdir}/libeasaccount.so.0.0.0
+%{_libdir}/libeasclient.so.0
+%{_libdir}/libeasclient.so.0.0.0
+%{_libdir}/libeastest.so.0
+%{_libdir}/libeastest.so.0.0.0
+%{_libexecdir}/activesyncd
+%{_datadir}/dbus-1/services/org.meego.activesyncd.service
+%{_datadir}/locale/*/LC_MESSAGES/activesyncd.mo
+%{_datadir}/glib-2.0/schemas/org.meego.activesyncd.account.gschema.xml
+%{_datadir}/glib-2.0/schemas/org.meego.activesyncd.gschema.xml
+
+
+%files devel
+%{_includedir}/eas-daemon/
+%{_libdir}/evolution-data-server/libevoeas.so
+%{_libdir}/libeas.so
+%{_libdir}/libeasaccount.so
+%{_libdir}/libeasclient.so
+%{_libdir}/libeastest.so
+%{_libdir}/pkgconfig/libeasaccount.pc
+%{_libdir}/pkgconfig/libeasclient.pc

--- a/libeasaccount/src/eas-account.c
+++ b/libeasaccount/src/eas-account.c
@@ -569,7 +569,7 @@ eas_account_set_from_info(EasAccount *account, const EasAccountInfo* accountinfo
 	if (accountinfo->device_id && accountinfo->device_id[0])
 		eas_account_set_device_id (account, accountinfo->device_id);
 	eas_account_set_protocol_version (account, accountinfo->protocol_version);
-	if (accountinfo->server_protocols && accountinfo->server_protocols[0])
+	if (accountinfo->server_protocols && accountinfo->server_protocols)
 		eas_account_set_server_protocols (account, accountinfo->server_protocols);
 	g_debug("eas_account_set_from_info--");	
 	return TRUE;


### PR DESCRIPTION
This makes it simpler for me to try evolution-activiesync out w/o having to install devel libraries and splattering the filesystem of target machines.
May not be ideal yet, but better than nothing, le tme know if you are interested.
